### PR TITLE
add publishers for maximum speeds

### DIFF
--- a/src/EduDrive.cpp
+++ b/src/EduDrive.cpp
@@ -47,6 +47,10 @@ namespace edu
         _pubEnabled = this->create_publisher<std_msgs::msg::ByteMultiArray>("enabled", 1);
         _pubRPM     = this->create_publisher<std_msgs::msg::Float32MultiArray>("rpm", 1);
 
+        // Publisher of maximum values
+        _pubMaxVelocity  = this->create_publisher<geometry_msgs::msg::Twist>("maximums/velocities", 1);
+        _pubMaxRPMs      = this->create_publisher<std_msgs::msg::Float32MultiArray>("maximums/rpms", 1);
+
         // Publisher of carrier shield
         _pubTemp             = this->create_publisher<std_msgs::msg::Float32>("temperature", 1);
         _pubVoltageAdapter   = this->create_publisher<std_msgs::msg::Float32>("voltageAdapter", 1);
@@ -297,6 +301,29 @@ namespace edu
 
         _pubRPM->publish(msgRPM);
         _pubEnabled->publish(msgEnabled);
+
+        geometry_msgs::msg::Twist msgMaxVelocities;
+        msgMaxVelocities.linear.x = _vMax;
+        msgMaxVelocities.angular.x = _omegaMax;
+        _pubMaxVelocity->publish(msgMaxVelocities);
+
+        std_msgs::msg::Float32MultiArray msgMaxRPMs;
+        msgMaxRPMs.layout.data_offset = 0;
+        std_msgs::msg::MultiArrayDimension dim1;
+        dim1.label = "controllers";
+        dim1.size = _mc.size();
+        dim1.stride = _mc.size();
+        msgMaxRPMs.layout.dim.push_back(dim1);
+        std_msgs::msg::MultiArrayDimension dim2;
+	dim2.label = "motors";
+	dim2.size = 1;
+	dim2.stride = 2;
+        msgMaxRPMs.layout.dim.push_back(dim2);
+        for ( auto &mc : _mc ) {
+           msgMaxRPMs.data.push_back(mc->getRPMMax());
+           msgMaxRPMs.data.push_back(0.f);
+        }
+        _pubMaxRPMs->publish(msgMaxRPMs);
 
         std_msgs::msg::Float32 msgTemperature;
         msgTemperature.data = _adapter->getTemperature();

--- a/src/EduDrive.h
+++ b/src/EduDrive.h
@@ -100,7 +100,11 @@ private:
     // Data available from motor controllers
     rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr      _pubEnabled;
     rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr   _pubRPM;
-    
+
+    // Maximum speeds
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr          _pubMaxVelocity;
+    rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr   _pubMaxRPMs;
+
     // Data available from adapter board
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr             _pubTemp;
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr             _pubVoltageAdapter;

--- a/src/MotorController.cpp
+++ b/src/MotorController.cpp
@@ -364,6 +364,11 @@ bool MotorController::setRPM(float rpm[2])
   return _can->send(&_cf);
 }
 
+float MotorController::getRPMMax()
+{
+  return _params.rpmMax;
+}
+
 void MotorController::getWheelResponse(float response[2])
 {
   if(_params.responseMode == CAN_RESPONSE_RPM)

--- a/src/MotorController.h
+++ b/src/MotorController.h
@@ -293,6 +293,12 @@ namespace edu
     bool setRPM(float rpm[2]);
 
     /**
+     * Accessor to maximum RPM
+     * @return maximum RPM
+     */
+    float getRPMMax();
+
+    /**
      * Get either motor revolutions per minute or motor position (encoder ticks). This depends on the configuration canResponseMode.
      * @param[out] response revolutions per minute for motor 1 and 2 / position of motor 1 and 2. This is a modulo 2^15 value.
      */


### PR DESCRIPTION
> Idea: controlling Node can map Twist and RPM override to match robots'
maximum values

- publish maximum velocities (vMax, omegaMax)
- publish maximum RPM values